### PR TITLE
Add basic Jest tests

### DIFF
--- a/backend/__tests__/customerModel.test.js
+++ b/backend/__tests__/customerModel.test.js
@@ -1,0 +1,18 @@
+const customerModel = require('../models/customerModel');
+const db = require('../database');
+
+describe('customerModel', () => {
+  afterAll(done => {
+    db.close(done);
+  });
+
+  test('getCustomerById returns existing customer', done => {
+    customerModel.getCustomerById(7, (err, customer) => {
+      expect(err).toBeNull();
+      expect(customer).toBeDefined();
+      expect(customer.first_name).toBe('Kerry');
+      expect(customer.last_name).toBe('Allison');
+      done();
+    });
+  });
+});

--- a/backend/__tests__/customerRoutes.test.js
+++ b/backend/__tests__/customerRoutes.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const customerRoutes = require('../routes/customers');
+const db = require('../database');
+
+const app = express();
+app.use(bodyParser.json());
+app.use('/api/customers', customerRoutes);
+
+afterAll(done => {
+  db.close(done);
+});
+
+describe('Customer routes', () => {
+  test('GET /api/customers/:id returns a customer', async () => {
+    const res = await request(app).get('/api/customers/7');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.first_name).toBe('Kerry');
+    expect(res.body.last_name).toBe('Allison');
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "init-db": "node initDb.js"
+    "init-db": "node initDb.js",
+    "test": "jest"
   },
   "dependencies": {
     "body-parser": "^1.20.2",
@@ -15,6 +16,11 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/frontend/src/components/Header.test.js
+++ b/frontend/src/components/Header.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Header from './Header';
+
+test('renders application title', () => {
+  render(
+    <BrowserRouter>
+      <Header />
+    </BrowserRouter>
+  );
+  expect(screen.getByText(/Frau Tonies Berlin/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest and supertest configs to the backend
- create backend model and route tests
- add a simple React Testing Library test for the Header component

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test -- --watchAll=false` in `frontend` *(fails: react-scripts not found)*