### PR TITLE
Add delete option for compositions

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -76,3 +76,11 @@ export const deleteCustomer = async (id) => {
   if (!res.ok) throw new Error('Fehler beim Löschen des Kunden');
   return res.json();
 };
+
+export const deleteComposition = async (id) => {
+  const res = await fetch(`${API_BASE_URL}/compositions/${id}`, {
+    method: 'DELETE'
+  });
+  if (!res.ok) throw new Error('Fehler beim Löschen der Zusammenstellung');
+  return res.json();
+};


### PR DESCRIPTION
## Summary
- allow deleting compositions via API
- show a delete icon in CustomerDetailPage for expanded compositions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b8b1e881c8323a59596d752551d9d