### PR TITLE
Add Apple Silicon sqlite rebuild guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ Die Anwendung bietet folgende Hauptfunktionen:
 - **Backend startet nicht**: Überprüfen Sie, ob Port 5000 bereits verwendet wird
 - **Frontend zeigt keine Daten an**: Stellen Sie sicher, dass das Backend läuft
 - **Datenimport schlägt fehl**: Überprüfen Sie das Format Ihrer Excel-Dateien
+- **Apple-Silicon (ARM64) und SQLite**: Wenn beim Start des Backends die Meldung
+  `node_sqlite3.node` mit *incompatible architecture (have 'x86_64', need 'arm64')*
+  erscheint, wurde das SQLite-Binding für die falsche Architektur installiert.
+  Entfernen Sie das bestehende `node_modules`-Verzeichnis im Backend und bauen Sie
+  das Binding neu:
+  ```
+  cd backend
+  rm -rf node_modules
+  npm install
+  npm run rebuild-sqlite
+  ```
+  Anschließend sollte der Backend-Start ohne Architekturfehler funktionieren.
 
 ## Cloudflare-Tunnel
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "init-db": "node initDb.js",
-    "test": "jest"
+    "test": "jest",
+    "rebuild-sqlite": "npm rebuild sqlite3 --build-from-source --force"
   },
   "dependencies": {
     "body-parser": "^1.20.2",


### PR DESCRIPTION
## Summary
- add npm script to rebuild sqlite bindings from source
- document Apple Silicon instructions for rebuilding sqlite when architecture mismatch occurs

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935c1ed797c83238a96104349f5178e)