### PR TITLE
Update sqlite rebuild instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ Die Anwendung bietet folgende Hauptfunktionen:
 - **Apple-Silicon (ARM64) und SQLite**: Wenn beim Start des Backends die Meldung
   `node_sqlite3.node` mit *incompatible architecture (have 'x86_64', need 'arm64')*
   erscheint, wurde das SQLite-Binding für die falsche Architektur installiert.
-  Entfernen Sie das bestehende `node_modules`-Verzeichnis im Backend und bauen Sie
-  das Binding neu:
+  Entfernen Sie das bestehende `node_modules`-Verzeichnis im Backend und lassen Sie
+  das vorkompilierte Binding erneut herunterladen (so ist keine lokale
+  `distutils`-Installation nötig):
   ```
   cd backend
   rm -rf node_modules

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon server.js",
     "init-db": "node initDb.js",
     "test": "jest",
-    "rebuild-sqlite": "npm rebuild sqlite3 --build-from-source --force"
+    "rebuild-sqlite": "npm rebuild sqlite3 --update-binary --force"
   },
   "dependencies": {
     "body-parser": "^1.20.2",


### PR DESCRIPTION
## Summary
- adjust the sqlite rebuild script to download prebuilt bindings instead of forcing a source build
- update the README Apple Silicon guidance to reflect the new rebuild approach and avoid distutils errors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935c3783fc0832399c6b237242cab29)